### PR TITLE
ci(cd): publish to npm with provenance

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
     contents: write
+    id-token: write
     pull-requests: write
 
 jobs:
@@ -49,4 +50,4 @@ jobs:
                   npm i --ignore-scripts
                   npm run build
                   npm pkg delete commitlint devDependencies jest scripts
-                  npm publish --ignore-scripts
+                  npm publish --ignore-scripts --provenance


### PR DESCRIPTION
See https://github.blog/changelog/2023-04-19-npm-provenance-public-beta/