### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	"author": "Frazer Smith <frazer.dev@outlook.com>",
 	"funding": "https://github.com/sponsors/Fdawgs",
 	"engines": {
-		"node": ">=14.0.0"
+		"node": ">=14.18.0"
 	},
 	"scripts": {
 		"build": "tsc && jsdoc2md src/index.js > API.md && npm run lint:prettier:fix",

--- a/scripts/license-checker.js
+++ b/scripts/license-checker.js
@@ -3,7 +3,7 @@
 
 "use strict";
 
-const { promisify } = require("util");
+const { promisify } = require("node:util");
 const { init } = require("license-checker");
 // @ts-ignore
 const copyLeftLicenses = require("spdx-copyleft");

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const { execFile, spawn } = require("child_process");
-const { promisify } = require("util");
-const { readFile } = require("fs/promises");
+const { execFile, spawn } = require("node:child_process");
+const { promisify } = require("node:util");
+const { readFile } = require("node:fs/promises");
 const { gt, lt } = require("semver");
 const path = require("upath");
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,8 +2,8 @@
 
 "use strict";
 
-const { execFile } = require("child_process");
-const { promisify } = require("util");
+const { execFile } = require("node:child_process");
+const { promisify } = require("node:util");
 const isHtml = require("is-html");
 const { gt, lt } = require("semver");
 const path = require("upath");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
 		"declaration": true,
 		"emitDeclarationOnly": true,
 		"lib": ["ES2019"],
-		"moduleResolution": "nodenext",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"outDir": "types",
 		"resolveJsonModule": true,
 		"strict": true


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/37246/files#r588397158