### PR TITLE
ci(ci): ignore github actions prs when automerging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
             github.event.pull_request.draft == false &&
             github.event_name == 'pull_request' &&
             github.event.pull_request.user.login == 'dependabot[bot]'
+            !startsWith(github.event.pull_request.title, 'ci')
         runs-on: ubuntu-latest
         permissions:
             pull-requests: write


### PR DESCRIPTION
needs a pat with workflows write permissions, just as well

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
