### PR TITLE
perf(index): replace `Object.keys` with `Object.entries`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,12 +60,17 @@ function parseOptions(acceptedOptions, options, version) {
 	const args = [];
 	/** @type {string[]} */
 	const invalidArgs = [];
-	const keys = Object.keys(options);
-	const keysLength = keys.length;
-	for (let i = 0; i < keysLength; i += 1) {
-		const key = keys[i];
+	/**
+	 * Imperative loops are faster than functional loops.
+	 * @see {@link https://romgrk.com/posts/optimizing-javascript#3-avoid-arrayobject-methods || Optimizing JavaScript}
+	 */
+	const entries = Object.entries(options);
+	const entriesLength = entries.length;
+	for (let i = 0; i < entriesLength; i += 1) {
+		// Destructuring adds overhead, so use index access
+		const key = entries[i][0];
 		if (Object.hasOwn(acceptedOptions, key)) {
-			const option = options[key];
+			const option = entries[i][1];
 			const acceptedOption = acceptedOptions[key];
 
 			// eslint-disable-next-line valid-typeof -- `type` is a string


### PR DESCRIPTION
Using both key and value anyway. From benchmarking it shaves a few milliseconds off every `convert()` call, which, when churning 3mil+ documents all adds up.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
