### PR TITLE
test(utils/gen-combos): replace accumulator spread with object.assign

### DIFF
--- a/test_resources/utils/gen-combos.js
+++ b/test_resources/utils/gen-combos.js
@@ -13,9 +13,15 @@ function generateCombos(originalSet) {
 	const powerSet = btPowerSetRecursive(originalSet);
 
 	// Merge resulting array of arrays of objects into a single array of objects
-	const reducedPowerSet = powerSet.map((subset) =>
-		subset.reduce((acc, cur) => ({ ...acc, ...cur }), {})
-	);
+	const reducedPowerSet = powerSet.map((subset) => {
+		const combined = {};
+
+		const subsetLength = subset.length;
+		for (let i = 0; i < subsetLength; i += 1) {
+			Object.assign(combined, subset[i]);
+		}
+		return combined;
+	});
 
 	// Remove duplicates and return
 	return [...new Set(reducedPowerSet)];


### PR DESCRIPTION
Using an accumulator with a spread causes a time complexity of `O(n^2)` instead of `O(n)` because it's creating an increasingly growing new object on every iteration. With object.assign, the accumulator is being mutated rather than creating a new object.

[This blog post](https://www.richsnapp.com/article/2019/06-09-reduce-spread-anti-pattern) covers why using spread (`{...obj}`) syntax in accumulators like `reduce` is a bad idea.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
