### PR TITLE
perf(index): only call `normalize()` once per file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -240,10 +240,12 @@ class UnRTF {
 	 * @returns {Promise<string>}  A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async convert(file, options = {}) {
+		let normalizedFile;
+
 		// Catch empty strings, missing files, and non-RTF files, as UnRTF will attempt to convert them
 		let fileHandle;
 		try {
-			const normalizedFile = normalize(file);
+			normalizedFile = normalize(file);
 			// eslint-disable-next-line security/detect-non-literal-fs-filename -- File open is wanted
 			fileHandle = await open(normalizedFile, "r");
 
@@ -275,7 +277,7 @@ class UnRTF {
 			options,
 			this.#unrtfVersion
 		);
-		args.push(normalize(file));
+		args.push(normalizedFile);
 
 		return new Promise((resolve, reject) => {
 			const child = spawn(pathResolve(this.#unrtfPath, "unrtf"), args);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [ ] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
