### PR TITLE
perf(index): resolve unrtf bin path once on init, not on every call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,8 @@ function parseOptions(acceptedOptions, options, version) {
 }
 
 class UnRTF {
+	#unrtfBin;
+
 	#unrtfPath;
 
 	#unrtfVersion;
@@ -157,8 +159,10 @@ class UnRTF {
 		}
 		this.#unrtfPath = normalize(this.#unrtfPath);
 
+		this.#unrtfBin = pathResolve(this.#unrtfPath, "unrtf");
+
 		// Version needed for option validation; which is output to stderr
-		const version = spawnSync(pathResolve(this.#unrtfPath, "unrtf"), [
+		const version = spawnSync(this.#unrtfBin, [
 			"--version",
 		]).stderr.toString();
 		this.#unrtfVersion = UNRTF_VERSION_REG.exec(version)?.[1] || "";
@@ -280,7 +284,7 @@ class UnRTF {
 		args.push(normalizedFile);
 
 		return new Promise((resolve, reject) => {
-			const child = spawn(pathResolve(this.#unrtfPath, "unrtf"), args);
+			const child = spawn(this.#unrtfBin, args);
 
 			let stdOut = "";
 			let stdErr = "";


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [ ] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
