### PR TITLE
perf(index): cache buffers to reduce `alloc()` and `toString()` calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,9 @@ const ERROR_MSGS = {
 	3221225477: "Segmentation fault",
 };
 const RTF_MAGIC_NUMBER = "{\\rtf1";
+const RTF_MAGIC_BUFFER = Buffer.from(RTF_MAGIC_NUMBER);
 const RTF_MAGIC_NUMBER_LENGTH = RTF_MAGIC_NUMBER.length;
+const RTF_MAGIC_NUMBER_LENGTH_BUFFER = Buffer.alloc(RTF_MAGIC_NUMBER_LENGTH);
 
 // Cache immutable regex as they are expensive to create and garbage collect
 const UNRTF_PATH_REG = /(.+)unrtf/u;
@@ -254,14 +256,14 @@ class UnRTF {
 			fileHandle = await open(normalizedFile, "r");
 
 			const { buffer } = await fileHandle.read(
-				Buffer.alloc(RTF_MAGIC_NUMBER_LENGTH),
+				RTF_MAGIC_NUMBER_LENGTH_BUFFER,
 				0,
 				RTF_MAGIC_NUMBER_LENGTH,
 				0
 			);
 
 			// Check for RTF specific magic number
-			if (buffer.toString() !== RTF_MAGIC_NUMBER) {
+			if (!buffer.equals(RTF_MAGIC_BUFFER)) {
 				throw new Error(
 					"File is not the correct media type, expected 'application/rtf'"
 				);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [ ] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
