### PR TITLE
refactor(index): enable regex charset and unicode with `v` flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,9 @@ const RTF_MAGIC_BUFFER = Buffer.from(RTF_MAGIC_NUMBER);
 const RTF_MAGIC_NUMBER_LENGTH = RTF_MAGIC_NUMBER.length;
 
 // Cache immutable regex as they are expensive to create and garbage collect
-const UNRTF_PATH_REG = /(.+)unrtf/u;
+const UNRTF_PATH_REG = /(.+)unrtf/v;
 // UnRTF version output is inconsistent between versions but always starts with the semantic version number
-const UNRTF_VERSION_REG = /^(\d{1,2}\.\d{1,2}\.\d{1,2})/u;
+const UNRTF_VERSION_REG = /^(\d{1,2}\.\d{1,2}\.\d{1,2})/v;
 
 /**
  * @typedef {object} OptionDetails

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -31,7 +31,7 @@ const file = `${testDirectory}test-rtf-complex.rtf`;
 
 // Cache immutable regex as they are expensive to create and garbage collect
 const HTML_REG =
-	/^\s*<!doctype html\b[^>]*>|<(?:html|body)\b[^>]*>|<x-[^>]+>/iu;
+	/^\s*<!doctype html\b[^>]*>|<(?:html|body)\b[^>]*>|<x-[^>]+>/iv;
 
 /**
  * @description Returns the path to the UnRTF binary based on the OS.
@@ -41,7 +41,7 @@ function getTestBinaryPath() {
 	const which = spawnSync(platform === "win32" ? "where" : "which", [
 		"unrtf",
 	]).stdout.toString();
-	let unrtfPath = /(.+)unrtf/u.exec(which)?.[1];
+	let unrtfPath = /(.+)unrtf/v.exec(which)?.[1];
 
 	if (platform === "win32" && !unrtfPath) {
 		unrtfPath = join(__dirname, "lib", "win32", "unrtf-0.19.3", "bin");
@@ -130,7 +130,7 @@ describe("Node-UnRTF module", () => {
 				join(testBinaryPath, "unrtf"),
 				["--version"]
 			);
-			version = /^(\d{1,2}\.\d{1,2}\.\d{1,2})/u.exec(stderr)[1];
+			version = /^(\d{1,2}\.\d{1,2}\.\d{1,2})/v.exec(stderr)[1];
 		});
 
 		it("Converts RTF if any valid options are set", async () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [ ] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
