### PR TITLE
ci(ci): only send coverage to coveralls on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,11 +142,7 @@ jobs:
               run: npm run test:unit:coverage
 
             - name: Coveralls parallel
-              if: >
-                  github.event_name == 'push' ||
-                  (github.event_name == 'pull_request' &&
-                   github.event.pull_request.head.repo.full_name == github.repository &&
-                   github.event.pull_request.user.login != 'dependabot[bot]')
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main'
               uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -156,11 +152,7 @@ jobs:
     coverage:
         name: Aggregate Coverage Calculations
         needs: unit-tests
-        if: >
-            github.event_name == 'push' ||
-            (github.event_name == 'pull_request' &&
-             github.event.pull_request.head.repo.full_name == github.repository &&
-             github.event.pull_request.user.login != 'dependabot[bot]')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         runs-on: ubuntu-latest
         permissions:
             contents: read


### PR DESCRIPTION
Stops the annoying bot comment; coverage enforced by c8 or jest