### PR TITLE
chore(.editorconfig): add file to enforce consistent coding styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Prettier will use these settings
+end_of_line = lf
+indent_style = tab
+indent_size = 4
+max_line_length = 80
+
+[*.{css,html,scss}]
+max_line_length = 120

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,16 +1,12 @@
 {
 	"arrowParens": "always",
-	"endOfLine": "lf",
 	"semi": true,
-	"tabWidth": 4,
 	"trailingComma": "es5",
-	"useTabs": true,
 	"overrides": [
 		{
 			"files": ["*.css", "*.html", "*.scss"],
 			"options": {
-				"bracketSameLine": true,
-				"printWidth": 120
+				"bracketSameLine": true
 			}
 		}
 	]


### PR DESCRIPTION
Added an .editorconfig file and moved Prettier configuration to it.

This allows users to edit in [GitHub without formatting issues](https://github.com/editorconfig/editorconfig.github.com/pull/48), and also means a standard style across my repos regardless of what language is being used (don't need Prettier installed in every repo).