### PR TITLE
refactor(index): freeze `#acceptedOptions` object

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
 		"typescript": "~5.9.2"
 	},
 	"dependencies": {
+		"ice-barrage": "^1.0.0",
 		"semver": "^7.7.2"
 	},
 	"optionalDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const { spawn, spawnSync } = require("node:child_process");
 const { open } = require("node:fs/promises");
 const { normalize, resolve: pathResolve } = require("node:path");
 const { platform } = require("node:process");
+const freeze = require("ice-barrage");
 const { gt, lt } = require("semver");
 
 /**
@@ -31,7 +32,7 @@ const UNRTF_VERSION_REG = /^(\d{1,2}\.\d{1,2}\.\d{1,2})/u;
  */
 
 /**
- * @typedef {Readonly<Record<string, OptionDetails>>} UnRTFAcceptedOptions
+ * @typedef {Readonly<Record<string, Readonly<OptionDetails>>>} UnRTFAcceptedOptions
  */
 
 /**
@@ -119,7 +120,7 @@ class UnRTF {
 	#unrtfVersion;
 
 	/** @type {UnRTFAcceptedOptions} */
-	static #acceptedOptions = Object.freeze({
+	static #acceptedOptions = freeze({
 		noPictures: {
 			arg: "--nopict",
 			type: "boolean",


### PR DESCRIPTION
The class itself can still reassign private fields, so protect against that

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
