### PR TITLE
fix(index): skip version checks for `false` boolean options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,10 +90,11 @@ function parseOptions(acceptedOptions, options, version) {
 		const optionType = typeof option;
 
 		if (acceptedOption.type === optionType) {
-			// Skip boolean options if false
-			if (acceptedOption.type !== "boolean" || option) {
-				args.push(acceptedOption.arg);
+			// Boolean options set to false won't be passed to the binary; skip arg and version checks
+			if (acceptedOption.type === "boolean" && !option) {
+				continue;
 			}
+			args.push(acceptedOption.arg);
 		} else {
 			invalidArgs.push(
 				`Invalid value type provided for option '${key}', expected ${

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -362,7 +362,6 @@ describe("Node-UnRTF module", () => {
 			const unRtfMock = new UnRTFMock(testBinaryPath);
 
 			// outputPs and outputWpml have maxVersion 0.19.4
-
 			const options = {
 				noPictures: true,
 				outputPs: false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -317,6 +317,63 @@ describe("Node-UnRTF module", () => {
 			);
 		});
 
+		it("Does not reject when version-constrained boolean options are set to false on an older binary", async () => {
+			jest.doMock("node:child_process", () => ({
+				...originalChildProcess,
+				spawnSync: jest.fn(() => ({
+					stdout: {
+						toString: () => "/usr/bin/unrtf",
+					},
+					stderr: {
+						toString: () => "0.19.0",
+					},
+				})),
+			}));
+			require("node:child_process");
+			const { UnRTF: UnRTFMock } = require("../src/index");
+			const unRtfMock = new UnRTFMock(testBinaryPath);
+
+			// outputRtf requires v0.21.3+ and quiet requires v0.21.3+,
+			const options = {
+				noPictures: true,
+				outputRtf: false,
+				quiet: false,
+			};
+
+			await expect(
+				unRtfMock.convert(file, options)
+			).resolves.toStrictEqual(expect.any(String));
+		});
+
+		it("Does not reject when version-constrained boolean options are set to false on a newer binary", async () => {
+			jest.doMock("node:child_process", () => ({
+				...originalChildProcess,
+				spawnSync: jest.fn(() => ({
+					stdout: {
+						toString: () => "/usr/bin/unrtf",
+					},
+					stderr: {
+						toString: () => "0.21.0",
+					},
+				})),
+			}));
+			require("node:child_process");
+			const { UnRTF: UnRTFMock } = require("../src/index");
+			const unRtfMock = new UnRTFMock(testBinaryPath);
+
+			// outputPs and outputWpml have maxVersion 0.19.4
+
+			const options = {
+				noPictures: true,
+				outputPs: false,
+				outputWpml: false,
+			};
+
+			await expect(
+				unRtfMock.convert(file, options)
+			).resolves.toStrictEqual(expect.any(String));
+		});
+
 		it.each([
 			{
 				testName: "a non-zero code and no output",


### PR DESCRIPTION
Boolean options set to `false` are never passed to the underlying binary, so it is redundant doing version checking on them and throwing errors.

Probably a tiny performance boost in here as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
