### PR TITLE
refactor(index): use `path.dirname` over regex to resolve bin path

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,7 +6,7 @@
 
 const { execFile, spawnSync } = require("node:child_process");
 const { unlink } = require("node:fs/promises");
-const { join, normalize, sep } = require("node:path");
+const { dirname, join, normalize, sep } = require("node:path");
 const { platform } = require("node:process");
 const { promisify } = require("node:util");
 const {
@@ -42,10 +42,10 @@ const originalProcess = jest.requireActual("node:process");
  * @throws {Error} If the OS is not supported or the binaries are not found.
  */
 function getTestBinaryPath() {
-	const which = spawnSync(platform === "win32" ? "where" : "which", [
-		"unrtf",
-	]).stdout.toString();
-	let unrtfPath = /(.+)unrtf/u.exec(which)?.[1];
+	const which = spawnSync(platform === "win32" ? "where" : "which", ["unrtf"])
+		.stdout.toString()
+		.trim();
+	let unrtfPath = dirname(which);
 
 	if (platform === "win32" && !unrtfPath) {
 		// @ts-ignore: Optional dependency


### PR DESCRIPTION
Purpose-built path utility should be much more robust than my regex!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
