### PR TITLE
chore: use ts-expect-error over ts-ignore

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ function parseOptions(acceptedOptions, options, version) {
 			continue;
 		}
 
-		// @ts-ignore: Keys are from options, TS cannot infer this
+		// @ts-expect-error: Keys are from options, TS cannot infer this
 		const option = options[key];
 		const acceptedOption = acceptedOptions[key];
 		const optionType = typeof option;
@@ -310,7 +310,7 @@ class UnRTF {
 				);
 			}
 		} catch (err) {
-			// @ts-ignore: Code property found in fs errors
+			// @ts-expect-error: Code property found in fs errors
 			if (err instanceof Error && err.code !== "ENOENT") {
 				throw err;
 			}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -468,7 +468,7 @@ describe("Node-UnRTF module", () => {
 			"Rejects with an Error object if $testName",
 			async ({ filePath, options, expError }) => {
 				await expect(
-					// @ts-expect-error: Testing invalid parameters being passed
+					// @ts-expect-error: Testing invalid argument
 					unRtf.convert(filePath, {
 						noPictures: true,
 						...options,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
