### PR TITLE
ci(lock-threads): reduce frequency from daily to monthly

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -14,7 +14,7 @@ on:
         #        │  │ │ │ │
         #        │  │ │ │ │
         #        *  * * * *
-        - cron: "30 1 * * *"
+        - cron: "30 1 1 * *"
     # Allows this workflow to be run manually from the Actions tab
     workflow_dispatch:
 


### PR DESCRIPTION
This PR reduces the frequency of the lock-threads workflow from daily to monthly, reducing workflow run noise.