### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 # node-unrtf
 
-[![GitHub release](https://img.shields.io/github/release/Fdawgs/node-unrtf.svg)](https://github.com/Fdawgs/node-unrtf/releases/latest/)
-[![npm version](https://img.shields.io/npm/v/node-unrtf)](https://npmjs.com/package/node-unrtf)
+[![GitHub release](https://img.shields.io/github/v/release/Fdawgs/node-unrtf)](https://github.com/Fdawgs/node-unrtf/releases/latest)
+[![npm version](https://img.shields.io/npm/v/node-unrtf)](https://www.npmjs.com/package/node-unrtf)
 [![CI](https://github.com/Fdawgs/node-unrtf/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Fdawgs/node-unrtf/actions/workflows/ci.yml)
 [![Coverage status](https://coveralls.io/repos/github/Fdawgs/node-unrtf/badge.svg?branch=main)](https://coveralls.io/github/Fdawgs/node-unrtf?branch=main)
-[![code style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat)](https://github.com/prettier/prettier)
+[![code style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4?style=flat)](https://github.com/prettier/prettier)
 [![OSSF Scorecard](https://api.scorecard.dev/projects/github.com/Fdawgs/node-unrtf/badge)](https://scorecard.dev/viewer/?uri=github.com/Fdawgs/node-unrtf)
 
 > Asynchronous Node.js wrapper for the UnRTF conversion utility
@@ -40,7 +40,7 @@ An example of downloading the binary on a Debian system:
 sudo apt-get install unrtf
 ```
 
-For macOS, the binary can be installed with [Homebrew](https://brew.sh/):
+For macOS, the binary can be installed with [Homebrew](https://brew.sh):
 
 ```sh
 brew install unrtf


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup.