### PR TITLE
fix(index): hide spawned unrtf console window on windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -221,9 +221,11 @@ class UnRTF {
 			this.#unrtfPath = binPath;
 		} else {
 			/* istanbul ignore next: requires specific OS */
-			const which = spawnSync(platform === "win32" ? "where" : "which", [
-				"unrtf",
-			]).stdout.toString();
+			const which = spawnSync(
+				platform === "win32" ? "where" : "which",
+				["unrtf"],
+				{ windowsHide: true }
+			).stdout.toString();
 			// Use regex over dirname as `where` on Windows returns a newline-delimited list
 			const unrtfPath = UNRTF_PATH_REG.exec(which)?.[1];
 
@@ -253,9 +255,9 @@ class UnRTF {
 		this.#unrtfBin = pathResolve(this.#unrtfPath, "unrtf");
 
 		// Version needed for option validation; which is output to stderr
-		const version = spawnSync(this.#unrtfBin, [
-			"--version",
-		]).stderr.toString();
+		const version = spawnSync(this.#unrtfBin, ["--version"], {
+			windowsHide: true,
+		}).stderr.toString();
 		this.#unrtfVersion = UNRTF_VERSION_REG.exec(version)?.[1] || "";
 
 		if (!this.#unrtfVersion) {
@@ -333,7 +335,10 @@ class UnRTF {
 		args.push(normalizedFile);
 
 		return new Promise((resolve, reject) => {
-			const child = spawn(this.#unrtfBin, args, { signal });
+			const child = spawn(this.#unrtfBin, args, {
+				signal,
+				windowsHide: true,
+			});
 
 			let stdOut = "";
 			let stdErr = "";


### PR DESCRIPTION
On Windows, `spawn` may briefly flash a console window for the child process.
Teeny tiny performance boost on Windows OS as the window isn't visible/created.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
