### PR TITLE
fix(index): add guard for short files in magic number check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ pnpm-lock.yaml
 yarn.lock
 
 # Test files
-*.wmf
 *.emf
 *.png
+*.wmf
+test/fixtures/short-file-test.rtf

--- a/src/index.js
+++ b/src/index.js
@@ -302,15 +302,18 @@ class UnRTF {
 			// eslint-disable-next-line security/detect-non-literal-fs-filename -- File open is wanted
 			fileHandle = await open(normalizedFile, "r");
 
-			const { buffer } = await fileHandle.read(
-				Buffer.alloc(RTF_MAGIC_NUMBER_LENGTH),
+			const readBuf = Buffer.allocUnsafe(RTF_MAGIC_NUMBER_LENGTH);
+			const { bytesRead } = await fileHandle.read(
+				readBuf,
 				0,
 				RTF_MAGIC_NUMBER_LENGTH,
 				0
 			);
 
-			// Check for RTF specific magic number
-			if (!buffer.equals(RTF_MAGIC_BUFFER)) {
+			if (
+				bytesRead < RTF_MAGIC_NUMBER_LENGTH ||
+				!readBuf.equals(RTF_MAGIC_BUFFER)
+			) {
 				throw new Error(
 					"File is not the correct media type, expected 'application/rtf'"
 				);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@
 "use strict";
 
 const { execFile, spawnSync } = require("node:child_process");
-const { unlink } = require("node:fs/promises");
+const { unlink, writeFile } = require("node:fs/promises");
 const { join, normalize, sep } = require("node:path");
 const { platform } = require("node:process");
 const { promisify } = require("node:util");
@@ -384,6 +384,7 @@ describe("Node-UnRTF module", () => {
 			).resolves.toStrictEqual(expect.any(String));
 		});
 
+		// Child process exit code handling tests
 		it.each([
 			{
 				testName: "a non-zero code and no output",
@@ -438,6 +439,7 @@ describe("Node-UnRTF module", () => {
 			}
 		);
 
+		// General argument validation tests
 		it.each([
 			{
 				testName: "file is not RTF format",
@@ -448,7 +450,6 @@ describe("Node-UnRTF module", () => {
 				expError:
 					"File is not the correct media type, expected 'application/rtf'",
 			},
-
 			{
 				testName: "file is missing",
 				filePath: undefined,
@@ -488,6 +489,44 @@ describe("Node-UnRTF module", () => {
 			}
 		);
 
+		// File size validation tests
+		it.each([
+			{
+				testName: "file is empty (0 bytes)",
+				content: Buffer.alloc(0),
+			},
+			{
+				testName: "file is 1 byte",
+				content: Buffer.from("{"),
+			},
+			{
+				testName: "file is 3 bytes with RTF-like prefix",
+				content: Buffer.from("{\\r"),
+			},
+			{
+				testName:
+					"file is 5 bytes (one byte short of the magic number)",
+				content: Buffer.from("{\\rtf"),
+			},
+		])("Rejects with an Error object if $testName", async ({ content }) => {
+			const shortFile = `${testDirectory}short-file-test.rtf`;
+			await writeFile(shortFile, content);
+			try {
+				await expect(
+					unRtf.convert(shortFile, { noPictures: true })
+				).rejects.toThrow(
+					expect.objectContaining({
+						message: expect.stringContaining(
+							"File is not the correct media type, expected 'application/rtf'"
+						),
+					})
+				);
+			} finally {
+				await unlink(shortFile);
+			}
+		});
+
+		// AbortSignal handling tests
 		it.each([
 			{
 				testName: "signal is already aborted before starting",


### PR DESCRIPTION

`fileHandle.read()` may return fewer bytes than requested for files smaller than 6 bytes. Without checking `bytesRead`, the comparison against the RTF magic number `{\rtf1` could produce a false positive on truncated input.

Also switches to `Buffer.allocUnsafe` as all bytes are immediately overwritten by the read, so the filling of all zeroes in `Buffer.alloc` was wasted. Teeny tiny micro-optimisation that saves ~2.84µs per call. All adds up when converting millions of files though!

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
