### PR TITLE
perf(index): use native stream consumer and events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -355,11 +355,13 @@ class UnRTF {
 			signal,
 		});
 
-		const [stdout, stderr, [code]] = await Promise.all([
+		const [stdoutRaw, stderrRaw, [code]] = await Promise.all([
 			streamToText(child.stdout),
 			streamToText(child.stderr),
 			once(child, "close"),
 		]);
+		const stdout = stdoutRaw.trim();
+		const stderr = stderrRaw.trim();
 
 		if (stdout.length > 0) {
 			return stdout;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 "use strict";
 
 const { spawn, spawnSync } = require("node:child_process");
+const { once } = require("node:events");
 const { open } = require("node:fs/promises");
 const { normalize, resolve: pathResolve } = require("node:path");
 const { platform } = require("node:process");
+const { text: streamToText } = require("node:stream/consumers");
 const freeze = require("ice-barrage");
 const { gt, lt } = require("semver");
 
@@ -348,49 +350,27 @@ class UnRTF {
 		);
 		args.push(normalizedFile);
 
-		return new Promise((resolve, reject) => {
-			const child = spawn(this.#unrtfBin, args, {
-				...CHILD_PROCESS_OPTS,
-				signal,
-			});
-
-			let stdOut = "";
-			let stdErr = "";
-
-			child.stdout.on("data", (data) => {
-				stdOutChunks.push(data);
-				stdOutLength += data.length;
-			});
-
-			child.stderr.on("data", (data) => {
-				stdErrChunks.push(data);
-				stdErrLength += data.length;
-			});
-
-			child.once("error", reject);
-			child.once("close", (code) => {
-				if (stdOut !== "") {
-					resolve(stdOut.trim());
-				} else if (stdErr === "") {
-					reject(
-						new Error(
-							ERROR_MSGS[code ?? -1] ||
-								`unrtf ${args.join(
-									" "
-								)} exited with code ${code}`
-						)
-					);
-				} else {
-					reject(
-						new Error(
-							Buffer.concat(stdErrChunks, stdErrLength)
-								.toString("utf8")
-								.trim()
-						)
-					);
-				}
-			});
+		const child = spawn(this.#unrtfBin, args, {
+			...CHILD_PROCESS_OPTS,
+			signal,
 		});
+
+		const [stdout, stderr, [code]] = await Promise.all([
+			streamToText(child.stdout),
+			streamToText(child.stderr),
+			once(child, "close"),
+		]);
+
+		if (stdout.length > 0) {
+			return stdout;
+		}
+		if (stderr.length === 0) {
+			throw new Error(
+				ERROR_MSGS[code ?? -1] ||
+					`unrtf ${args.join(" ")} exited with code ${code}`
+			);
+		}
+		throw new Error(stderr);
 	}
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -354,13 +354,8 @@ class UnRTF {
 				signal,
 			});
 
-			/** @type {Buffer[]} */
-			const stdOutChunks = [];
-			/** @type {Buffer[]} */
-			const stdErrChunks = [];
-			let stdOutLength = 0;
-			let stdErrLength = 0;
-			let errorHandled = false;
+			let stdOut = "";
+			let stdErr = "";
 
 			child.stdout.on("data", (data) => {
 				stdOutChunks.push(data);
@@ -372,24 +367,11 @@ class UnRTF {
 				stdErrLength += data.length;
 			});
 
-			child.on("error", (err) => {
-				errorHandled = true;
-				reject(err);
-			});
-
-			child.on("close", (code) => {
-				// If an error was already emitted, don't process the close event
-				if (errorHandled) {
-					return;
-				}
-
-				if (stdOutLength > 0) {
-					resolve(
-						Buffer.concat(stdOutChunks, stdOutLength)
-							.toString("utf8")
-							.trim()
-					);
-				} else if (stdErrLength === 0) {
+			child.once("error", reject);
+			child.once("close", (code) => {
+				if (stdOut !== "") {
+					resolve(stdOut.trim());
+				} else if (stdErr === "") {
 					reject(
 						new Error(
 							ERROR_MSGS[code ?? -1] ||


### PR DESCRIPTION
Cleaner than the `errorHandled` boolean and still rejects if an abort signal is passed.
Functionally the same.

Benchmarks show it to be ~2x faster.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
