### PR TITLE
fix(index): decode child stdout/stderr as one contiguous buffer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -354,16 +354,22 @@ class UnRTF {
 				signal,
 			});
 
-			let stdOut = "";
-			let stdErr = "";
+			/** @type {Buffer[]} */
+			const stdOutChunks = [];
+			/** @type {Buffer[]} */
+			const stdErrChunks = [];
+			let stdOutLength = 0;
+			let stdErrLength = 0;
 			let errorHandled = false;
 
 			child.stdout.on("data", (data) => {
-				stdOut += data;
+				stdOutChunks.push(data);
+				stdOutLength += data.length;
 			});
 
 			child.stderr.on("data", (data) => {
-				stdErr += data;
+				stdErrChunks.push(data);
+				stdErrLength += data.length;
 			});
 
 			child.on("error", (err) => {
@@ -377,9 +383,13 @@ class UnRTF {
 					return;
 				}
 
-				if (stdOut !== "") {
-					resolve(stdOut.trim());
-				} else if (stdErr === "") {
+				if (stdOutLength > 0) {
+					resolve(
+						Buffer.concat(stdOutChunks, stdOutLength)
+							.toString("utf8")
+							.trim()
+					);
+				} else if (stdErrLength === 0) {
 					reject(
 						new Error(
 							ERROR_MSGS[code ?? -1] ||
@@ -389,7 +399,13 @@ class UnRTF {
 						)
 					);
 				} else {
-					reject(new Error(stdErr.trim()));
+					reject(
+						new Error(
+							Buffer.concat(stdErrChunks, stdErrLength)
+								.toString("utf8")
+								.trim()
+						)
+					);
 				}
 			});
 		});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,10 +4,12 @@
 
 "use strict";
 
+const { EventEmitter } = require("node:events");
 const { execFile, spawnSync } = require("node:child_process");
 const { unlink, writeFile } = require("node:fs/promises");
 const { join, normalize, sep } = require("node:path");
 const { platform } = require("node:process");
+const { Readable } = require("node:stream");
 const { promisify } = require("node:util");
 const {
 	afterEach,
@@ -276,6 +278,66 @@ describe("Node-UnRTF module", () => {
 			expect(res).toMatch(expected.stringMatch);
 		});
 
+		it.each([
+			{
+				testName: "2-byte character (£) is split across boundary",
+				chunks: [
+					Buffer.from([0xc2]), // first byte of £
+					Buffer.from([0xa3, 0x21]), // last byte of £ + '!'
+				],
+				expected: "£!",
+			},
+			{
+				testName: "3-byte character (€) is split across boundary",
+				chunks: [
+					Buffer.from([0xe2, 0x82]), // first 2 bytes of €
+					Buffer.from([0xac, 0x21]), // last byte of € + '!'
+				],
+				expected: "€!",
+			},
+			{
+				testName: "4-byte character (𝄞) is split across boundary",
+				chunks: [
+					Buffer.from([0xf0, 0x9d]), // first 2 bytes of 𝄞
+					Buffer.from([0x84, 0x9e, 0x21]), // last 2 bytes of 𝄞 + '!'
+				],
+				expected: "𝄞!",
+			},
+		])(
+			"Correctly decodes stdout when $testName",
+			async ({ chunks, expected }) => {
+				jest.doMock("node:child_process", () => ({
+					...originalChildProcess,
+					spawn: jest.fn(() => {
+						const emitter =
+							/** @type {import("node:child_process").ChildProcess} */ (
+								new EventEmitter()
+							);
+						emitter.stdout = Readable.from(chunks);
+						emitter.stderr = new Readable({
+							read() {
+								this.push(null);
+							},
+						});
+						emitter.stdout.on("end", () => {
+							setImmediate(() => emitter.emit("close", 0));
+						});
+						return emitter;
+					}),
+				}));
+				require("node:child_process");
+				const { UnRTF: UnRTFMock } = require("../src/index");
+				const unRtfMock = new UnRTFMock(testBinaryPath);
+
+				const result = await unRtfMock.convert(file, {
+					noPictures: true,
+				});
+
+				expect(result).toBe(expected);
+				expect(result).not.toContain("\uFFFD");
+			}
+		);
+
 		it("Rejects with an Error object if option provided is only available in a later version of the UnRTF binary than what was provided", async () => {
 			jest.doMock("node:child_process", () => ({
 				...originalChildProcess,
@@ -404,31 +466,27 @@ describe("Node-UnRTF module", () => {
 		])(
 			"Rejects with an Error object if UnRTF exits with $testName",
 			async ({ exitCode, expectedError }) => {
-				jest.doMock("node:child_process", () => {
-					const { EventEmitter } = require("node:events");
-					const { Readable } = require("node:stream");
-					return {
-						...originalChildProcess,
-						spawn: jest.fn(() => {
-							const emitter =
-								/** @type {import("node:child_process").ChildProcess} */ (
-									new EventEmitter()
-								);
-							emitter.stdout = new Readable({
-								read() {
-									this.push(null);
-								},
-							});
-							emitter.stderr = new Readable({
-								read() {
-									this.push(null);
-								},
-							});
-							setImmediate(() => emitter.emit("close", exitCode));
-							return emitter;
-						}),
-					};
-				});
+				jest.doMock("node:child_process", () => ({
+					...originalChildProcess,
+					spawn: jest.fn(() => {
+						const emitter =
+							/** @type {import("node:child_process").ChildProcess} */ (
+								new EventEmitter()
+							);
+						emitter.stdout = new Readable({
+							read() {
+								this.push(null);
+							},
+						});
+						emitter.stderr = new Readable({
+							read() {
+								this.push(null);
+							},
+						});
+						setImmediate(() => emitter.emit("close", exitCode));
+						return emitter;
+					}),
+				}));
 				require("node:child_process");
 				const { UnRTF: UnRTFMock } = require("../src/index");
 				const unRtfMock = new UnRTFMock(testBinaryPath);


### PR DESCRIPTION
Crazily I was just looking to reduce the transient heap size that would bloat during conversion but ended up finding a chunk boundary bug.

This PR updates `convert()` to collect stdout/stderr chunks into Buffer arrays and decode once on close via `Buffer.concat().toString()` instead of accumulating them with `stdOut += data`.

The previous approach implicitly called `Buffer.prototype.toString()` per chunk, which decoded each chunk independently. Multibyte UTF-8 sequences split across pipe chunk boundaries were replaced with `U+FFFD`, silently corrupting output.

Decoding once over contiguous bytes fixes the boundary bug and lowers peak heap use during conversion by ~40-50% in benchmarks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
