### PR TITLE
perf(index): use null prototype for faster property lookup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,9 @@ const CHILD_PROCESS_OPTS = Object.freeze({
  * @type {Readonly<Record<string, string>>}
  * @ignore
  */
+// @ts-expect-error -- TS cannot infer that __proto__ is a special property and not part of the record type
 const ERROR_MSGS = Object.freeze({
+	__proto__: null,
 	3221225477: "Segmentation fault",
 });
 const RTF_MAGIC_NUMBER = "{\\rtf1";


### PR DESCRIPTION
Slower cold start in exchange for ~50% faster lookup.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
