### PR TITLE
refactor(index): ignore stdin for child processes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,14 +9,13 @@ const { text: streamToText } = require("node:stream/consumers");
 const freeze = require("ice-barrage");
 const { gt, lt } = require("semver");
 
-/**
- * @type {Readonly<import("node:child_process").CommonOptions>}
- * @ignore
- */
-const CHILD_PROCESS_OPTS = Object.freeze({
-	stdio: ["ignore", "pipe", "pipe"],
-	windowsHide: true,
-});
+/** @ignore */
+const CHILD_PROCESS_OPTS = Object.freeze(
+	/** @type {import("node:child_process").SpawnOptionsWithStdioTuple<"ignore", "pipe", "pipe">} */ ({
+		stdio: ["ignore", "pipe", "pipe"],
+		windowsHide: true,
+	})
+);
 
 /**
  * @type {Readonly<Record<string, string>>}

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const { gt, lt } = require("semver");
  * @ignore
  */
 const CHILD_PROCESS_OPTS = Object.freeze({
+	stdio: ["ignore", "pipe", "pipe"],
 	windowsHide: true,
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,8 +18,8 @@ const CHILD_PROCESS_OPTS = Object.freeze(
 );
 
 /**
- * @type {Readonly<Record<string, string>>}
  * @ignore
+ * @type {Readonly<Record<string, string>>}
  */
 // @ts-expect-error -- TS cannot infer that __proto__ is a special property and not part of the record type
 const ERROR_MSGS = Object.freeze({


### PR DESCRIPTION
Ignore stdin for all child processes since none require input. This avoids creating an unused pipe and prevents children from waiting for stdin, whilst keeping stdout and stderr piped.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
