### PR TITLE
fix(index): prefix leading-dash filepaths with `./`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -350,7 +350,13 @@ class UnRTF {
 			options,
 			this.#unrtfVersion
 		);
-		args.push(normalizedFile);
+
+		// Protect against reading filepath with leading `-` as an option as UnRTF has no `--` terminator
+		args.push(
+			normalizedFile.startsWith("-")
+				? `./${normalizedFile}`
+				: normalizedFile
+		);
 
 		const child = spawn(this.#unrtfBin, args, {
 			...CHILD_PROCESS_OPTS,

--- a/test/fixtures/-n.rtf
+++ b/test/fixtures/-n.rtf
@@ -1,0 +1,1 @@
+{\rtf1\ansi Dash guard fixture}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -9,7 +9,7 @@ const { execFile, spawnSync } = require("node:child_process");
 // eslint-disable-next-line n/no-unsupported-features/node-builtins -- Tests, not in distributed code
 const { glob, writeFile, unlink } = require("node:fs/promises");
 const { join, normalize, sep } = require("node:path");
-const { platform } = require("node:process");
+const { chdir, cwd, platform } = require("node:process");
 const { Readable } = require("node:stream");
 const { promisify } = require("node:util");
 const {
@@ -416,9 +416,9 @@ describe("Node-UnRTF module", () => {
 				quiet: false,
 			};
 
-			await expect(
-				unRtfMock.convert(file, options)
-			).resolves.toStrictEqual(expect.any(String));
+			await expect(unRtfMock.convert(file, options)).resolves.toMatch(
+				HTML_REG
+			);
 		});
 
 		it("Does not reject when version-constrained boolean options are set to false on a newer binary", async () => {
@@ -444,9 +444,9 @@ describe("Node-UnRTF module", () => {
 				outputWpml: false,
 			};
 
-			await expect(
-				unRtfMock.convert(file, options)
-			).resolves.toStrictEqual(expect.any(String));
+			await expect(unRtfMock.convert(file, options)).resolves.toMatch(
+				HTML_REG
+			);
 		});
 
 		// Child process exit code handling tests
@@ -635,7 +635,23 @@ describe("Node-UnRTF module", () => {
 				{ signal: controller.signal }
 			);
 
-			expect(result).toStrictEqual(expect.any(String));
+			expect(result).toMatch(HTML_REG);
+		});
+
+		it("Converts RTF file with leading dash in filepath", async () => {
+			const originalCwd = cwd();
+			chdir(testDirectory);
+
+			try {
+				const result = await unRtf.convert("-n.rtf", {
+					noPictures: true,
+				});
+
+				expect(result).toMatch(HTML_REG);
+				expect(result).toMatch("Dash guard fixture");
+			} finally {
+				chdir(originalCwd);
+			}
 		});
 	});
 });


### PR DESCRIPTION
A filepath that starts with `-` never converts, as UnRTF reads it as an option and has no `--` terminator.
`convert()` now prefixes those paths with `./`, which resolves to the same file.

Resolves [CWE-88](https://cwe.mitre.org/data/definitions/88.html).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/Fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
